### PR TITLE
feat: create the basic project files

### DIFF
--- a/code/SmartMedical.pro
+++ b/code/SmartMedical.pro
@@ -1,0 +1,34 @@
+QT       += core gui
+
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+
+CONFIG += c++11
+
+# The following define makes your compiler emit warnings if you use
+# any Qt feature that has been marked deprecated (the exact warnings
+# depend on your compiler). Please consult the documentation of the
+# deprecated API in order to know how to port your code away from it.
+DEFINES += QT_DEPRECATED_WARNINGS
+
+# You can also make your code fail to compile if it uses deprecated APIs.
+# In order to do so, uncomment the following line.
+# You can also select to disable deprecated APIs only up to a certain version of Qt.
+#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+
+SOURCES += \
+    main.cpp \
+    widget.cpp
+
+HEADERS += \
+    widget.h
+
+FORMS += \
+    widget.ui
+
+TRANSLATIONS += \
+    SmartMedical_zh_CN.ts
+
+# Default rules for deployment.
+qnx: target.path = /tmp/$${TARGET}/bin
+else: unix:!android: target.path = /opt/$${TARGET}/bin
+!isEmpty(target.path): INSTALLS += target

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -1,0 +1,11 @@
+#include "widget.h"
+
+#include <QApplication>
+
+int main(int argc, char *argv[])
+{
+    QApplication a(argc, argv);
+    Widget w;
+    w.show();
+    return a.exec();
+}

--- a/code/widget.cpp
+++ b/code/widget.cpp
@@ -1,0 +1,15 @@
+#include "widget.h"
+#include "ui_widget.h"
+
+Widget::Widget(QWidget *parent)
+    : QMainWindow(parent)
+    , ui(new Ui::Widget)
+{
+    ui->setupUi(this);
+}
+
+Widget::~Widget()
+{
+    delete ui;
+}
+

--- a/code/widget.h
+++ b/code/widget.h
@@ -1,0 +1,21 @@
+#ifndef WIDGET_H
+#define WIDGET_H
+
+#include <QMainWindow>
+
+QT_BEGIN_NAMESPACE
+namespace Ui { class Widget; }
+QT_END_NAMESPACE
+
+class Widget : public QMainWindow
+{
+    Q_OBJECT
+
+public:
+    Widget(QWidget *parent = nullptr);
+    ~Widget();
+
+private:
+    Ui::Widget *ui;
+};
+#endif // WIDGET_H

--- a/code/widget.ui
+++ b/code/widget.ui
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Widget</class>
+ <widget class="QMainWindow" name="Widget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Widget</string>
+  </property>
+  <widget class="QWidget" name="centralwidget"/>
+  <widget class="QMenuBar" name="menubar"/>
+  <widget class="QStatusBar" name="statusbar"/>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Create a basic QT project, without any functions added.

## Sourcery 摘要

设置基本的 Qt 应用程序脚手架

新功能：
- 添加 Qt 项目文件，包含 core、gui、widgets 模块和 C++11 配置
- 添加 main.cpp，包含 QApplication 入口点和 Widget 实例化
- 添加 Widget 类脚手架，包含头文件、实现文件和 UI 表单
- 添加中文翻译文件占位符

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Set up basic Qt application scaffold

New Features:
- Add Qt project file with core, gui, widgets modules and C++11 configuration
- Add main.cpp with QApplication entry point and Widget instantiation
- Add Widget class scaffold with header, implementation and UI form
- Add translation file placeholder for Chinese

</details>